### PR TITLE
disable daily-service notifications

### DIFF
--- a/nagios/objects/templates.cfg
+++ b/nagios/objects/templates.cfg
@@ -202,4 +202,5 @@ define service{
         retry_interval          1440
         notification_interval   0
         register                0
+        notifications_enabled   0
 }


### PR DESCRIPTION
To suppress messages from the ssllabs check until it is known to be
reliable.