### PR TITLE
increase service check timeout to 120s

### DIFF
--- a/nagios/nagios.cfg
+++ b/nagios/nagios.cfg
@@ -588,7 +588,7 @@ auto_rescheduling_window=180
 # ocsp command, and performance data commands.  All values are in
 # seconds.
 
-service_check_timeout=60
+service_check_timeout=120
 host_check_timeout=30
 event_handler_timeout=30
 notification_timeout=30


### PR DESCRIPTION
The ssllabs check is taking over 60s and timing out.