### PR TITLE
manually set ssllabs api url to https://api.ssllabs.com/api/v3/

### DIFF
--- a/nagios/conf.d/commands.cfg
+++ b/nagios/conf.d/commands.cfg
@@ -30,5 +30,5 @@ define command{
 
 define command{
         command_name    check_ssllabs
-        command_line    /usr/bin/check-ssl-qualys.rb -d $HOSTADDRESS$ -c A
+        command_line    /usr/bin/check-ssl-qualys.rb --api-url https://api.ssllabs.com/api/v3/ -d $HOSTADDRESS$ -c A
 }


### PR DESCRIPTION
The default v2 api url is dead.