### PR TITLE
rm ssh check for git-lfs.lsst.codes

### DIFF
--- a/nagios/conf.d/hostgroups.cfg
+++ b/nagios/conf.d/hostgroups.cfg
@@ -23,5 +23,5 @@ define hostgroup {
 define hostgroup {
         hostgroup_name          ssh-servers
         alias                   SSH Servers
-        members                 git-lfs.lsst.codes, community, status
+        members                 community, status
 }


### PR DESCRIPTION
This is now a k8s deployment without a sshd service.