### PR TITLE
Remove monitoring for api.github.com since GH considers it too frequent

### DIFF
--- a/nagios/conf.d/host-api.github.com.cfg
+++ b/nagios/conf.d/host-api.github.com.cfg
@@ -1,14 +1,18 @@
-define host {
-        use                     dm-square-server-https
-        host_name               api.github.com
-        alias                   api.github.com
-        address                 api.github.com
-}
+#
+# Github gets tectchy about a new login every ten minutes.  So...never mind.
+#
 
-define service {
-        host_name               api.github.com
-        service_description     URL /user/orgs
-        check_command           check_https_authenticated!-u https://api.github.com/user/orgs
-        use                     generic-service
-        notification_interval   0
-}
+#define host{
+#        use                     dm-square-server-https
+#        host_name               api.github.com
+#        alias                   api.github.com
+#        address                 api.github.com
+#        }
+
+#define service {
+#       host_name		api.github.com
+#       service_description	URL /user/orgs
+#       check_command		check_https_authenticated!-u https://api.github.com/user/orgs
+#       use			generic-service
+#       notification_interval	0
+#}

--- a/nagios/conf.d/hostgroups.cfg
+++ b/nagios/conf.d/hostgroups.cfg
@@ -15,8 +15,9 @@ define hostgroup {
 define hostgroup {
         hostgroup_name          https-servers
         alias                   HTTPS Servers
-        members                 git-lfs.lsst.codes, community, status, github.com, api.github.com, squash, squash-api, squash-bokeh
+        members                 git-lfs.lsst.codes, community, status, github.com, squash, squash-api, squash-bokeh
 }
+# Stop api.github.com since they get angry about it.
 
 # Squash and CI require logins; some of the others require specific URLs
 


### PR DESCRIPTION
a login cadence.