### PR TITLE
[DM-14180] Fix nagios checks after new squash deployment

### DIFF
--- a/nagios/conf.d/host-squash-restful-api.lsst.codes.cfg
+++ b/nagios/conf.d/host-squash-restful-api.lsst.codes.cfg
@@ -1,20 +1,20 @@
 define host {
         use                     dm-square-server-https
-        host_name               squash-api
-        alias                   squash-api.lsst.codes
-        address                 squash-api.lsst.codes
+        host_name               squash-restful-api
+        alias                   squash-restful-api.lsst.codes
+        address                 squash-restful-api.lsst.codes
 }
 
 define service {
-        host_name               squash-api
+        host_name               squash-restful-api
         service_description     URL /
-        check_command           check_https!-u https://squash-api.lsst.codes/
+        check_command           check_https!-u https://squash-restful-api.lsst.codes/
         use                     generic-service
         notification_interval   0
 }
 
 define service {
-        host_name               squash-api
+        host_name               squash-restful-api
         service_description     TLS cert expiration
         check_command           check_tls_cert
         use                     generic-service
@@ -22,7 +22,7 @@ define service {
 }
 
 define service {
-        host_name               squash-api
+        host_name               squash-restful-api
         service_description     ssllabs
         check_command           check_ssllabs
         use                     daily-service

--- a/nagios/conf.d/hostgroups.cfg
+++ b/nagios/conf.d/hostgroups.cfg
@@ -15,7 +15,7 @@ define hostgroup {
 define hostgroup {
         hostgroup_name          https-servers
         alias                   HTTPS Servers
-        members                 git-lfs.lsst.codes, community, status, github.com, squash, squash-api, squash-bokeh
+        members                 git-lfs.lsst.codes, community, status, github.com, squash, squash-restful-api, squash-bokeh
 }
 # Stop api.github.com since they get angry about it.
 


### PR DESCRIPTION
- squash-api service was renamed to squash-restful-api 