### PR TITLE
Temporarily disable efd-prod notifications

### DIFF
--- a/nagios/conf.d/deploy-efd-prod.cfg
+++ b/nagios/conf.d/deploy-efd-prod.cfg
@@ -1,3 +1,7 @@
+# NOTE: notifications for the efd-prod deployment are disbaled
+# for now as we are not using this service at the moment.
+# This should be reviewed once we have the LDF EFD deployment in place.
+
 # efd0.lsst.codes
 
 define host {
@@ -12,6 +16,7 @@ define service {
         service_description     kafka broker
         check_command           check_kafka!9094!--topic sqre-alive-test
         use                     generic-service
+        notifications_enabled          0
 }
 
 # efd1.lsst.codes
@@ -28,6 +33,7 @@ define service {
         service_description     kafka broker
         check_command           check_kafka!9094!--topic sqre-alive-test
         use                     generic-service
+        notifications_enabled          0
 }
 
 # efd2.lsst.codes
@@ -44,6 +50,7 @@ define service {
         service_description     kafka broker
         check_command           check_kafka!9094!--topic sqre-alive-test
         use                     generic-service
+        notifications_enabled          0
 }
 
 # grafana-efd.lsst.codes
@@ -60,6 +67,7 @@ define service {
         service_description     HTTPS
         check_command           check_https
         use                     generic-service
+        notifications_enabled          0
 }
 
 define service {
@@ -67,6 +75,7 @@ define service {
         service_description     HTTP redirect-to HTTPS
         check_command           check_https_redirect
         use                     generic-service
+        notifications_enabled          0
 }
 
 define service {
@@ -74,6 +83,7 @@ define service {
         service_description     TLS cert expiration
         check_command           check_tls_cert
         use                     generic-service
+        notifications_enabled          0
 }
 
 define service {
@@ -81,6 +91,7 @@ define service {
         service_description     ssllabs
         check_command           check_ssllabs
         use                     daily-service
+        notifications_enabled          0
 }
 
 # prometheus-efd.lsst.codes
@@ -97,6 +108,7 @@ define service {
         service_description     HTTPS
         check_command           check_https
         use                     generic-service
+        notifications_enabled          0
 }
 
 define service {
@@ -104,6 +116,7 @@ define service {
         service_description     HTTP redirect-to HTTPS
         check_command           check_https_redirect
         use                     generic-service
+        notifications_enabled          0
 }
 
 define service {
@@ -111,6 +124,7 @@ define service {
         service_description     TLS cert expiration
         check_command           check_tls_cert
         use                     generic-service
+        notifications_enabled          0
 }
 
 define service {
@@ -118,4 +132,5 @@ define service {
         service_description     ssllabs
         check_command           check_ssllabs
         use                     daily-service
+        notifications_enabled          0
 }


### PR DESCRIPTION
Notifications for the efd-prod deployment at GKE are being disabled for now as we are not using this service at the moment. 